### PR TITLE
Unbind all  + bind chat keys

### DIFF
--- a/LuaUI/widgets/gui_standalone_lobby.lua
+++ b/LuaUI/widgets/gui_standalone_lobby.lua
@@ -11,7 +11,35 @@ function widget:GetInfo()
 end
 
 function widget:Initialize()
-	Spring.SendCommands("ResBar 0", "ToolTip 0", "Clock 0", "Info 0") --  "Console 0",
+	Spring.SendCommands({
+							"ResBar 0",
+							"ToolTip 0",
+							"Clock 0",
+							"Info 0",
+		--					"Console 0",
+
+							"unbindall",
+							
+							"bind Any+enter chat",
+							"bind Any+enter  edit_return",
+							
+							"bind Any+escape  edit_escape",
+							"bind Any+tab  edit_complete",
+							"bind Any+backspace  edit_backspace",
+							"bind Any+delete  edit_delete",
+							"bind Alt+left  edit_home",
+							"bind Any+home  edit_home",
+							"bind Alt+right  edit_end",
+							"bind Any+end  edit_end",
+							"bind Any+left  edit_prev_char",
+							"bind Any+right  edit_next_char",
+							"bind Ctrl+left  edit_prev_word",
+							"bind Ctrl+right  edit_next_word",
+							"bind Any+up  edit_prev_line",
+							"bind Any+down  edit_next_line",
+
+							"bind Ctrl+v pastetext",
+	})
 	Spring.SetConfigInt("MouseDragScrollThreshold", 0, true)
 	Spring.LoadCmdColorsConfig("mouseBox 0.0 0.0 0.0 0.0")
 	Spring.SetDrawSky(false)


### PR DESCRIPTION
Remove the shift-esc menu, esc mgs on console, ctrl+F1,2,3 keys to change camera ,increase/decrease game spedd , terrain detail ... etc
All.

and bind the chat with enter key for debug console and the edit keys for manage the chat itelf

this can be usefull to bind keys to lobby functions like esc to close windows or short cuts to acces diferent chat tabs duno...

edit: keyboard hungry of "d's"