### PR TITLE
Fix #468, checkbox vs actual value mismatch

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -85,7 +85,7 @@ function Configuration:init()
 
 	self.loadLocalWidgets = false
 	self.displayBots = false
-	self.displayBadEngines2 = true
+	self.displayBadEngines2 = false
 	self.allEnginesRunnable = true
 	self.doNotSetAnySpringSettings = false
 	self.agressivelySetBorderlessWindowed = false


### PR DESCRIPTION
The checkbox defaults to unticked but the value defaults to true.