### PR TITLE
Add automatic testing for encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ script:
   # (Disabled for now)
   # - luacheck LuaMenu --enable 1
   - luacheck LuaMenu
+  - ./autotest.sh

--- a/autotest.sh
+++ b/autotest.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+FAILING=
+
+fail() {
+  echo "$@"
+  FAILING="y"
+}
+
+while read f; do
+  diff /dev/null "$f" | tail -1 | grep -q '^\\ No newline at end of file' > /dev/null && fail "Warning: $f: No trailing newline";
+  if grep -q $'[^ \t][ \t]\+$' "$f"; then
+    # Everybody hates trailing whitespace after content
+    fail "Warning: $f: Trailing whitespace after content";
+  else
+    # Most hate full line trailing whitespace; separated out to be disabled if desired
+    # grep -q $'[ \t]$' "$f" && fail "Warning: $f: Full line trailing whitespace";
+    :;
+  fi
+  file -i "$f" | cut -f2 -d: | grep -q -e 'us-ascii' -e 'utf-8' || fail "Warning: $f: Unusual file encoding";
+  grep -q $'\r' "$f" && fail "Warning: $f: Carriage return characters detected";
+done < <(git ls-files '*.lua' '*.tdf' '*.h' '*.glsl' '*.fs' '*.json' '*.txt' '*.css') 1>&2
+[ "x${FAILING}" == "x" ]


### PR DESCRIPTION
(And some formatting)

Testing for full line trailing whitespace is currently disabled, as the
working tree is full of it. This is easy enough enable again, if some
consensus can be reached on the matter.