### PR TITLE
fix spring protocol

### DIFF
--- a/LuaMenu/widgets/gui_login_window.lua
+++ b/LuaMenu/widgets/gui_login_window.lua
@@ -53,10 +53,11 @@ local function GetNewLoginWindow(failFunc)
 	local Configuration = WG.Chobby.Configuration
 	local steamMode = Configuration.canAuthenticateWithSteam and Configuration.wantAuthenticateWithSteam
 	Spring.Echo("steamMode", Configuration.canAuthenticateWithSteam, Configuration.wantAuthenticateWithSteam)
+	emailRequired = (WG.Server.protocol == "spring")
 	if steamMode then
 		currentLoginWindow = WG.Chobby.SteamLoginWindow(failFunc, nil, "main_window")
 	else
-		currentLoginWindow = WG.Chobby.LoginWindow(failFunc, nil, "main_window", {loginAfterRegister = true})
+		currentLoginWindow = WG.Chobby.LoginWindow(failFunc, nil, "main_window", {loginAfterRegister = true, emailRequired = emailRequired})
 	end
 	return currentLoginWindow
 end

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -303,8 +303,8 @@ end
 function Interface:_OnTASServer(protocolVersion, springVersion, udpPort, serverMode)
 	self:_OnConnect(protocolVersion, springVersion, udpPort, serverMode)
 end
-Interface.commands["TASServer"] = Interface._OnTASServer
-Interface.commandPattern["TASServer"] = "(%S+)%s+(%S+)%s+(%S+)%s+(%S+)"
+Interface.commands["TASSERVER"] = Interface._OnTASServer
+Interface.commandPattern["TASSERVER"] = "(%S+)%s+(%S+)%s+(%S+)%s+(%S+)"
 
 function Interface:_OnMOTD(message)
 	-- IGNORED

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -32,7 +32,7 @@ function Interface:Login(user, password, cpu, localIP, lobbyVersion)
 		localIP = "*"
 	end
 	password = VFS.CalculateHash(password, 0)
-	sentence = "LuaLobby " .. lobbyVersion .. "\t" .. self.agent .. "\t" .. "t l b cl"
+	sentence = "LuaLobby " .. lobbyVersion .. "\t" .. self.agent .. "\t" .. "b"
 	cmd = concat("LOGIN", user, password, "0", localIP, sentence)
 	self:_SendCommand(cmd)
 	return self


### PR DESCRIPTION
(1) stop sending no-longer needed compat flags, matching https://github.com/spring/uberserver/issues/328 (fwiw, i'm not sure 'b' should be sent by chobby either, normally this one would only be sent by autohosts)

(2) fix case in TASSERVER, matching a recent server-side change (-> fixes a chobby crash)

(3) fix fail in https://github.com/Spring-Chobby/Chobby/commit/3cc640ec809b654c8fbd6783a760db1f252c8a13 which deleted the check for which protocol was in use and prevented the email input box from ever showing...