### PR TITLE
Store friends on `FRIENDLIST`

### DIFF
--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -49,11 +49,13 @@ end
 ------------------------
 
 function Interface:FriendList()
+	self:super("FriendList")
 	self:_SendCommand("FRIENDLIST", true)
 	return self
 end
 
 function Interface:FriendRequestList()
+	self:super("FriendRequestList")
 	self:_SendCommand("FRIENDREQUESTLIST", true)
 	return self
 end

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -596,7 +596,16 @@ function Lobby:_OnUnfriend(userName)
 	self:_CallListeners("OnUnfriend", userName)
 end
 
-function Lobby:_OnFriendList()
+function Lobby:_OnFriendList(friends)
+	self.friends = friends
+	self.friendCount = #friends
+
+	for _, userName in pairs(self.friends) do
+		self.isFriend[userName] = true
+		local userInfo = self:TryGetUser(userName)
+		userInfo.isFriend = true
+	end
+
 	self:_CallListeners("OnFriendList", self:GetFriends())
 end
 


### PR DESCRIPTION
Provides a fix for #495 

`Interface` had been forwarding the command to `Lobby` but `Lobby` wasn’t handling the list. Now:
- updates `self.friends`, `self.friendCount`, and `self.isFriend[userName]` properties
- updates `userInfo.isFriend` for the associated user object if they are online.
- Hands the friends list to listeners (before, this was the only thing it did, resulting in an un-updated list being handed off)

Also, for completeness, `Interface:FriendList()` and `:FriendRequestList()` now forward the calls to `self:super()`. Although this has no meaningful effect, a precedent for this is set with other calls, so this should prevent certain errors should `Lobby` ever care to use these calls.