### PR TITLE
Add faction/side selector

### DIFF
--- a/LuaMenu/widgets/api_user_handler.lua
+++ b/LuaMenu/widgets/api_user_handler.lua
@@ -149,7 +149,7 @@ local function GetUserClanImage(userName, userControl)
 	return file, needDownload
 end
 
-local function GetUserComboBoxOptions(userName, isInBattle, userControl, showTeamColor)
+local function GetUserComboBoxOptions(userName, isInBattle, userControl, showTeamColor, showSide)
 	local userInfo = userControl.lobby:GetUser(userName) or {}
 	local userBattleInfo = userControl.lobby:GetUserBattleStatus(userName) or {}
 	local myUserName = userControl.lobby:GetMyUserName()
@@ -217,10 +217,14 @@ local function GetUserComboBoxOptions(userName, isInBattle, userControl, showTea
 		comboOptions[#comboOptions + 1] = "User Page"
 	end
 
-	if showTeamColor and
-	   (userName == myUserName or userBattleInfo.aiLib) and
-	   not userBattleInfo.isSpectator then
-		comboOptions[#comboOptions + 1] = "Change Color"
+	if (userName == myUserName or userBattleInfo.aiLib) and
+		not userBattleInfo.isSpectator then
+		if showTeamColor then
+			comboOptions[#comboOptions + 1] = "Change Color"
+		end
+		if showSide then
+			comboOptions[#comboOptions + 1] = "Change Side"
+		end
 	end
 
 	-- userControl.lobby:GetMyIsAdmin()
@@ -393,7 +397,8 @@ local function UpdateUserComboboxOptions(_, userName)
 		local userList = userListList[i]
 		local data = userList[userName]
 		if data then
-			data.mainControl.items = GetUserComboBoxOptions(userName, data.isInBattle, data, data.imTeamColor ~= nil)
+			data.mainControl.items = GetUserComboBoxOptions(userName, data.isInBattle, data,
+			                                                data.imTeamColor ~= nil, data.imSide ~= nil)
 		end
 	end
 end
@@ -403,7 +408,8 @@ local function UpdateUserActivity(listener, userName)
 		local userList = userListList[i]
 		local userControls = userList[userName]
 		if userControls then
-			userControls.mainControl.items = GetUserComboBoxOptions(userName, userControls.isInBattle, userControls, userControls.imTeamColor ~= nil)
+			userControls.mainControl.items = GetUserComboBoxOptions(userName, userControls.isInBattle, userControls,
+			                                                        userControls.imTeamColor ~= nil, data.imSide ~= nil)
 			userControls.imLevel.file = GetUserRankImageName(userName, userControls)
 			userControls.imLevel:Invalidate()
 
@@ -446,12 +452,19 @@ local function UpdateUserBattleStatus(listener, userName)
 				data.imSyncStatus.file = GetUserSyncStatus(userName, data)
 				data.imSyncStatus:Invalidate()
 			end
+			local battleStatus = data.lobby:GetUserBattleStatus(userName) or {}
+			local imageVisible = not battleStatus.isSpectator
 			if data.imTeamColor then
-				local battleStatus = data.lobby:GetUserBattleStatus(userName) or {}
-				local colorVisible = not battleStatus.isSpectator
 				data.imTeamColor.color = battleStatus.teamColor
-				data.imTeamColor:SetVisibility(colorVisible)
-				if colorVisible then
+				data.imTeamColor:SetVisibility(imageVisible)
+				if imageVisible then
+					data.imTeamColor:Invalidate()
+				end
+			end
+			if data.imSide then
+				data.imSide.file = WG.Chobby.Configuration:GetSideById(battleStatus.side).logo
+				data.imSide:SetVisibility(imageVisible)
+				if imageVisible then
 					data.imTeamColor:Invalidate()
 				end
 			end
@@ -491,6 +504,7 @@ local function GetUserControls(userName, opts)
 	local showModerator      = opts.showModerator
 	local comboBoxOnly       = opts.comboBoxOnly
 	local showTeamColor      = opts.showTeamColor
+	local showSide           = opts.showSide
 
 	local userControls = reinitialize or {}
 
@@ -544,7 +558,7 @@ local function GetUserControls(userName, opts)
 			maxDropDownWidth = large and 220 or 150,
 			minDropDownHeight = 0,
 			maxDropDownHeight = 300,
-			items = GetUserComboBoxOptions(userName, isInBattle, userControls, showTeamColor),
+			items = GetUserComboBoxOptions(userName, isInBattle, userControls, showTeamColor, showSide),
 			OnOpen = {
 				function (obj)
 					obj.tooltip = nil
@@ -619,6 +633,25 @@ local function GetUserControls(userName, opts)
 								else
 									userControls.lobby:UpdateAi(userName, {
 										teamColor = color
+									})
+								end
+							end
+						})
+					elseif selectedName == "Change Side" then
+						local battleStatus = userControls.lobby:GetUserBattleStatus(userName) or {}
+						if battleStatus.isSpectator then
+							return
+						end
+						WG.SideChangeWindow.CreateSideChangeWindow({
+							initialSide = battleStatus.side or 0,
+							OnAccepted = function(sideId)
+								if userName == userControls.lobby:GetMyUserName() then
+									userControls.lobby:SetBattleStatus({
+										side = sideId
+									})
+								else
+									userControls.lobby:UpdateAi(userName, {
+										side = sideId
 									})
 								end
 							end
@@ -701,6 +734,25 @@ local function GetUserControls(userName, opts)
 			checkFileExists = needDownload,
 		}
 		offset = offset + 21
+	end
+
+	if showSide then
+		local battleStatus = userControls.lobby:GetUserBattleStatus(userName) or {}
+		offset = offset + 2
+		userControls.imSide = Image:New {
+			name = "imSide",
+			x = offset,
+			y = offsetY,
+			width = 20,
+			height = 20,
+			parent = userControls.mainControl,
+			keepAspect = false,
+			file = WG.Chobby.Configuration:GetSideById(battleStatus.side or 0).logo,
+		}
+		offset = offset + 22
+		if battleStatus.isSpectator then
+			userControls.imSide:Hide()
+		end
 	end
 
 	offset = offset + 2
@@ -872,6 +924,7 @@ function userHandler.GetBattleUser(userName, isSingleplayer)
 		showModerator  = true,
 		showFounder    = true,
 		showTeamColor  = not WG.Chobby.Configuration.gameConfig.disableColorChoosing,
+		showSide       = WG.Chobby.Configuration:GetSideData() ~= nil,
 	})
 end
 
@@ -890,6 +943,7 @@ function userHandler.GetSingleplayerUser(userName)
 		isInBattle     = true,
 		isSingleplayer = true,
 		showTeamColor  = not WG.Chobby.Configuration.gameConfig.disableColorChoosing,
+		showSide       = WG.Chobby.Configuration:GetSideData() ~= nil,
 	})
 end
 

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -841,6 +841,24 @@ function Configuration:GetDefaultGameName()
 	return self.gameConfig._defaultGameArchiveName
 end
 
+function Configuration:GetSideData()
+	if not self.gameConfig then
+		return nil
+	end
+	return self.gameConfig.sidedata
+end
+
+function Configuration:GetSideById(sideId)
+	if sideId == nil then
+		return { name = nil, logo = nil }
+	end
+	local sidedata = Configuration:GetSideData()
+	if sidedata == nil or sideId < 0 or sideId > #sidedata - 1 then
+		return { name = nil, logo = nil }
+	end
+	return sidedata[sideId + 1]
+end
+
 function Configuration:GetIsRunning64Bit()
 	if self.isRunning64Bit ~= nil then
 		return self.isRunning64Bit

--- a/LuaMenu/widgets/gui_side_change_window.lua
+++ b/LuaMenu/widgets/gui_side_change_window.lua
@@ -1,0 +1,132 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function widget:GetInfo()
+	return {
+		name      = "Faction change window",
+		desc      = "Displays a faction change window popup.",
+		author    = "escaped",
+		date      = "2nd wave of new world re-order",
+		license   = "GNU LGPL, v2.1 or later",
+		layer     = 0,
+		enabled   = true  --  loaded by default?
+	}
+end
+
+local function CreateSideChangeWindow(opts)
+	opts = opts or {}
+	local selectedFaction = opts.initialSide
+
+	local Configuration = WG.Chobby.Configuration
+	local sidedata = Configuration:GetSideData()
+
+	local factionMap = {}
+	local factionNames = {}
+	for index, data in ipairs(sidedata) do
+		factionMap[data.name] = index - 1
+		table.insert(factionNames, data.name)
+	end
+
+	local sideChangeWindow = Window:New {
+		caption = "",
+		name = "sideChangeWindow",
+		parent = screen0,
+		width = 280,
+		height = 330,
+		resizable = false,
+		draggable = false,
+		classname = "main_window",
+	}
+
+	local function ChangeAccepted()
+		if opts.OnAccepted then
+			opts.OnAccepted(selectedFaction)
+		end
+	end
+	local function CloseFunction()
+		sideChangeWindow:Dispose()
+		sideChangeWindow = nil
+	end
+
+	local lblTitle = Label:New {
+		x = 0,
+		y = 15,
+		width = sideChangeWindow.width - sideChangeWindow.padding[1] - sideChangeWindow.padding[3],
+		height = 35,
+		align = "center",
+		font = Configuration:GetFont(4),
+		caption = "Choose Faction",
+		parent = sideChangeWindow,
+	}
+
+	local btnOK = Button:New {
+		x = "10%",
+		width = "30%",
+		bottom = 1,
+		height = 40,
+		caption = i18n("ok"),
+		font = Configuration:GetFont(2),
+		classname = "action_button",
+		OnClick = { CloseFunction, ChangeAccepted },
+		parent = sideChangeWindow,
+	}
+
+	local btnCancel = Button:New {
+		right = "10%",
+		width = "30%",
+		bottom = 1,
+		height = 40,
+		caption = i18n("cancel"),
+		font = Configuration:GetFont(2),
+		classname = "action_button",
+		OnClick = { CloseFunction },
+		parent = sideChangeWindow,
+	}
+
+	local imTeamFaction
+	local cmbFactions = ComboBox:New {
+		x = sideChangeWindow.width * 0.05,
+		y = 150,
+		width = sideChangeWindow.width * 0.5,
+		height = 40,
+		items = factionNames,
+		parent = sideChangeWindow,
+		font = Configuration:GetFont(2),
+		itemFontSize = Configuration:GetFont(2).size,
+		itemHeight = 30,
+		selected = selectedFaction + 1,
+		selectByName = true,
+		OnSelectName = {
+			function (obj, name)
+				local faction = factionMap[name]
+				if faction == nil then
+					return
+				end
+				selectedFaction = faction
+				imTeamFaction.file = Configuration:GetSideById(faction).logo
+				imTeamFaction:Invalidate()
+			end
+		},
+	}
+
+	imTeamFaction = Image:New {
+		name = "imTeamFaction",
+		x = cmbFactions.x + cmbFactions.width + 20,
+		y = 150,
+		width = 40,
+		height = 40,
+		parent = sideChangeWindow,
+		keepAspect = false,
+		file = Configuration:GetSideById(selectedFaction).logo,
+	}
+
+	WG.Chobby.PriorityPopup(sideChangeWindow, CloseFunction, CloseFunction, screen0)
+end
+
+function widget:Initialize()
+	VFS.Include(LUA_DIRNAME .. "widgets/chobby/headers/exports.lua", nil, VFS.RAW_FIRST)
+
+	WG.SideChangeWindow = {
+		CreateSideChangeWindow = CreateSideChangeWindow
+	}
+end

--- a/libs/liblobby/lobby/interface_skirmish.lua
+++ b/libs/liblobby/lobby/interface_skirmish.lua
@@ -92,6 +92,7 @@ function InterfaceSkirmish:_StartScript(gameName, mapName, playerName, friendLis
 					TeamLeader = 0,
 					AllyTeam = data.allyNumber,
 					RgbColor = getTeamColor(userName),
+					Side = WG.Chobby.Configuration:GetSideById(data.side).name,
 				}
 				maxAllyTeamID = math.max(maxAllyTeamID, data.allyNumber)
 				teamCount = teamCount + 1
@@ -115,6 +116,7 @@ function InterfaceSkirmish:_StartScript(gameName, mapName, playerName, friendLis
 						TeamLeader = playerCount,
 						AllyTeam = data.allyNumber,
 						RgbColor = getTeamColor(userName),
+						Side = WG.Chobby.Configuration:GetSideById(data.side).name,
 					}
 					teamCount = teamCount + 1
 					if friendsReplaceAI then
@@ -166,7 +168,7 @@ function InterfaceSkirmish:_StartScript(gameName, mapName, playerName, friendLis
 					TeamLeader = 0,
 					AllyTeam = data.allyNumber,
 					RgbColor = getTeamColor(userName),
-					Side = data.side,
+					Side = WG.Chobby.Configuration:GetSideById(data.side).name,
 				}
 				maxAllyTeamID = math.max(maxAllyTeamID, data.allyNumber)
 


### PR DESCRIPTION
Side selector is not based on game's data, but reads sidedata from `LuaMenu/configs/gameConfig/<game>/`
Default behaviour is not showing factions, as `WG.Chobby.Configuration.gameConfig.sidedata = nil`

BYAR-Chobby will have a full example, including logo images.
Dependent: https://github.com/beyond-all-reason/BYAR-Chobby/pull/67