### PR TITLE
discard_updatebattleinfo_for_not_connected_users

### DIFF
--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -898,6 +898,10 @@ end
 -- Bots have isBot=true, AIs have aiLib~=nil and humans are the remaining
 -- Example: _OnUpdateUserStatus("gajop", {isAway=false, isInGame=true})
 function Lobby:_OnUpdateUserBattleStatus(userName, status)
+	if not self.users[userName] then 
+		Spring.Echo("[liblobby] Error OnUpdateUserBattleStatus: Tried to update non connected user in battle: ", userName, status)
+		return
+	end
 	if not self.userBattleStatus[userName] then
 		self.userBattleStatus[userName] = {}
 	end


### PR DESCRIPTION
Hi,
We faced a problem on bar infrastructure, where chobby shows players in battle, which were already removed from battle and are disconnected from server.
This is caused by receiving CLIENTBATTLESTATUS after LEFTBATTLE and REMOVEUSER was already sent. This leads to adding the user again to battle.

With this PR I added a check, if user is in list of connected users before adding him to the battle by CLIENTBATTLESTATUS.

Only testet in bar infrastructure. Can´t tell if it conflicts with other protocols and infrastructures.
Hope chances are good, that this has no negative effect in other environments.

best regards
Fireball

