### PR TITLE
Discard updatebattleinfo for not connected users

### DIFF
--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -191,54 +191,6 @@ local function UpdateAndCreateMerge(userData, status)
 	return battleStatus, updated
 end
 
---n = pow(2,i) -- where i = 0,31
---print('{',n//1000000,',', n%1000000,'},')
-local bin2decmillion16 = { -- the <1M and >1M parts of 2^nth powers where n > 16
-	{ 0 , 65536 }, --16
-	{ 0 , 131072 }, --17
-	{ 0 , 262144 }, --18
-	{ 0 , 524288 }, --19
-	{ 1 , 48576 },
-	{ 2 , 97152 },
-	{ 4 , 194304 },
-	{ 8 , 388608 },
-	{ 16 , 777216 }, --24
-	{ 33 , 554432 }, --25
-	{ 67 , 108864 }, --26
-	{ 134 , 217728 }, --27
-	{ 268 , 435456 }, --28
-	{ 536 , 870912 },  --29
-	{ 1073 , 741824 }, --30
-	{ 2147 , 483648 }, -- 31
-	}
-
--- Combine two 16 bit numbers into a string-formatted 32-bit integer
-local function lsbmsb16tostring(lsb,msb)
-	local aboveamillion = 0
-	local belowamillion = lsb
-	for b = 1, 16 do
-		if math.bit_and(msb, 2^(b-1)) > 0 then
-			belowamillion = belowamillion + bin2decmillion16[b][2]
-			if belowamillion >= 1000000 then
-				aboveamillion = aboveamillion + math.floor(belowamillion/1000000)
-				belowamillion = belowamillion % 1000000
-			end
-			aboveamillion = aboveamillion + bin2decmillion16[b][1]
-		end
-	end
-
-	local statusstr = ""
-	if aboveamillion == 0 then
-		statusstr = ("%d"):format(belowamillion)
-	else
-		statusstr = ("%d%06d"):format(aboveamillion,belowamillion)
-	end
-	--if statusstr ~= tostring(lsb + 65536 * msb) then
-	--	Spring.Echo("Possible integer overflow issues!",statusstr, lsb + 65536 * msb)
-	--end
-	return statusstr
-end
-
 local function EncodeBattleStatus(battleStatus)
 	local playMode = 1
 	if battleStatus.isSpectator then
@@ -252,17 +204,28 @@ local function EncodeBattleStatus(battleStatus)
 	end
 
 	-- This nasty piece of code is because battlestatus can overflow the 24bits of float that Spring Lua supports:
-	local lsb16 =
+	local belowamillion =
 		(battleStatus.isReady and 2 or 0) +
 		lshift(battleStatus.teamNumber, 2) +
 		lshift(battleStatus.allyNumber, 6) +
 		lshift(playMode, 10)
 
-	local msb16 =
-		math.floor((lshift(battleStatus.sync, 6) + --Because sync actually has 3 values, 0, 1, 2 (unknown, synced, unsynced)
-		lshift(battleStatus.side, 8)))
+	local aboveamillion = nil
+	local bignum =
+		math.floor((lshift(battleStatus.sync, 22) + --Because sync actually has 3 values, 0, 1, 2 (unknown, synced, unsynced)
+		lshift(battleStatus.side, 24)))
+	
+	aboveamillion = math.floor(bignum / 1000000)
+	belowamillion = belowamillion + (bignum%1000000)
 
-	return lsbmsb16tostring(lsb16, msb16)
+	local statusstr = ""
+	if aboveamillion == 0 then 
+		statusstr = ("%d"):format(belowamillion)
+	else
+		statusstr = ("%d%06d"):format(aboveamillion,belowamillion)
+	end
+
+	return statusstr
 end
 
 local function EncodeTeamColor(teamColor)
@@ -680,46 +643,17 @@ Interface.commands["FRIENDREQUESTLISTEND"] = Interface._OnFriendRequestListEnd
 ------------------------
 -- Battle commands
 ------------------------
-local msblsb5 = { -- stores a table of each power of 10 >= 10^5 as the 16 bit top and bottom halfs of digits greater than the 5th digit
-	{ 1 , 34464 },
-	{ 15 , 16960 },
-	{ 152 , 38528 },
-	{ 1525 , 57600 },
-	{ 15258 , 51712 },
-}
 
--- splits a string-encoded 32bit unsigned integer into 16bit LSB and 16bit MSB
-local function split16fast(bignumstr)
-	local skipdigits = 5
-	local lsb = tonumber(string.sub(bignumstr, -skipdigits)) -- 5 length suffix
-	local msb = 0
-	for i= skipdigits + 1, string.len(bignumstr) do -- for each character of the big number string
-		local n = tonumber(string.sub(bignumstr,-i,-i)) -- get the current character
-		--print (i,string.sub(bignumstr,i,i),n)
-		for k = 1, n do  -- for each number value of current character
-			lsb = lsb + msblsb5[i - skipdigits][2] -- add the 16bit LSB of 10*i'th power
-			if lsb >= 65536 then -- if it overflows LSB, increment MSB
-				msb = msb + math.floor(lsb / 65536)
-				lsb = lsb % 65536
-			end
-			msb = msb + msblsb5[i - skipdigits][1] -- add the 16 bit MSB of 10*i'th power
-		end
-	end
-	--print (msb, lsb, lsb + msb *65536)
-	return lsb, msb
-end
 local function ParseBattleStatus(battleStatus)
-	local lsb, msb = split16fast(battleStatus)
-
-	--battleStatus = tonumber(battleStatus)
+	battleStatus = tonumber(battleStatus)
 	return {
-		isReady      = rshift(lsb, 1) % 2 == 1,
-		teamNumber   = rshift(lsb, 2) % 16,
-		allyNumber   = rshift(lsb, 6) % 16,
-		isSpectator  = rshift(lsb, 10) % 2 == 0,
-		handicap     = (lshift(msb, 5) + rshift(lsb, 11) ) % 128,
-		sync         = rshift(msb, 6) % 4,
-		side         = rshift(msb, 8) % 16,
+		isReady      = rshift(battleStatus, 1) % 2 == 1,
+		teamNumber   = rshift(battleStatus, 2) % 16,
+		allyNumber   = rshift(battleStatus, 6) % 16,
+		isSpectator  = rshift(battleStatus, 10) % 2 == 0,
+		handicap     = rshift(battleStatus, 11) % 128,
+		sync         = rshift(battleStatus, 22) % 4,
+		side         = rshift(battleStatus, 24) % 16,
 	}
 end
 

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -367,7 +367,7 @@ function Interface:AddAi(aiName, aiLib, allyNumber, version, aiOptions, battleSt
 		isReady = true,
 		teamNumber = self:GetUnusedTeamID(),
 		allyNumber = allyNumber,
-		playMode = true,
+		isSpectator = false,
 		sync = 1, -- (0 = unknown, 1 = synced, 2 = unsynced)
 		side = 0,
 	}

--- a/libs/liblobby/lobby/interface.lua
+++ b/libs/liblobby/lobby/interface.lua
@@ -191,6 +191,54 @@ local function UpdateAndCreateMerge(userData, status)
 	return battleStatus, updated
 end
 
+--n = pow(2,i) -- where i = 0,31
+--print('{',n//1000000,',', n%1000000,'},')
+local bin2decmillion16 = { -- the <1M and >1M parts of 2^nth powers where n > 16
+	{ 0 , 65536 }, --16
+	{ 0 , 131072 }, --17
+	{ 0 , 262144 }, --18
+	{ 0 , 524288 }, --19
+	{ 1 , 48576 },
+	{ 2 , 97152 },
+	{ 4 , 194304 },
+	{ 8 , 388608 },
+	{ 16 , 777216 }, --24
+	{ 33 , 554432 }, --25
+	{ 67 , 108864 }, --26
+	{ 134 , 217728 }, --27
+	{ 268 , 435456 }, --28
+	{ 536 , 870912 },  --29
+	{ 1073 , 741824 }, --30
+	{ 2147 , 483648 }, -- 31
+	}
+
+-- Combine two 16 bit numbers into a string-formatted 32-bit integer
+local function lsbmsb16tostring(lsb,msb)
+	local aboveamillion = 0
+	local belowamillion = lsb
+	for b = 1, 16 do
+		if math.bit_and(msb, 2^(b-1)) > 0 then
+			belowamillion = belowamillion + bin2decmillion16[b][2]
+			if belowamillion >= 1000000 then
+				aboveamillion = aboveamillion + math.floor(belowamillion/1000000)
+				belowamillion = belowamillion % 1000000
+			end
+			aboveamillion = aboveamillion + bin2decmillion16[b][1]
+		end
+	end
+
+	local statusstr = ""
+	if aboveamillion == 0 then
+		statusstr = ("%d"):format(belowamillion)
+	else
+		statusstr = ("%d%06d"):format(aboveamillion,belowamillion)
+	end
+	--if statusstr ~= tostring(lsb + 65536 * msb) then
+	--	Spring.Echo("Possible integer overflow issues!",statusstr, lsb + 65536 * msb)
+	--end
+	return statusstr
+end
+
 local function EncodeBattleStatus(battleStatus)
 	local playMode = 1
 	if battleStatus.isSpectator then
@@ -204,28 +252,17 @@ local function EncodeBattleStatus(battleStatus)
 	end
 
 	-- This nasty piece of code is because battlestatus can overflow the 24bits of float that Spring Lua supports:
-	local belowamillion =
+	local lsb16 =
 		(battleStatus.isReady and 2 or 0) +
 		lshift(battleStatus.teamNumber, 2) +
 		lshift(battleStatus.allyNumber, 6) +
 		lshift(playMode, 10)
 
-	local aboveamillion = nil
-	local bignum =
-		math.floor((lshift(battleStatus.sync, 22) + --Because sync actually has 3 values, 0, 1, 2 (unknown, synced, unsynced)
-		lshift(battleStatus.side, 24)))
-	
-	aboveamillion = math.floor(bignum / 1000000)
-	belowamillion = belowamillion + (bignum%1000000)
+	local msb16 =
+		math.floor((lshift(battleStatus.sync, 6) + --Because sync actually has 3 values, 0, 1, 2 (unknown, synced, unsynced)
+		lshift(battleStatus.side, 8)))
 
-	local statusstr = ""
-	if aboveamillion == 0 then 
-		statusstr = ("%d"):format(belowamillion)
-	else
-		statusstr = ("%d%06d"):format(aboveamillion,belowamillion)
-	end
-
-	return statusstr
+	return lsbmsb16tostring(lsb16, msb16)
 end
 
 local function EncodeTeamColor(teamColor)
@@ -643,17 +680,46 @@ Interface.commands["FRIENDREQUESTLISTEND"] = Interface._OnFriendRequestListEnd
 ------------------------
 -- Battle commands
 ------------------------
+local msblsb5 = { -- stores a table of each power of 10 >= 10^5 as the 16 bit top and bottom halfs of digits greater than the 5th digit
+	{ 1 , 34464 },
+	{ 15 , 16960 },
+	{ 152 , 38528 },
+	{ 1525 , 57600 },
+	{ 15258 , 51712 },
+}
 
+-- splits a string-encoded 32bit unsigned integer into 16bit LSB and 16bit MSB
+local function split16fast(bignumstr)
+	local skipdigits = 5
+	local lsb = tonumber(string.sub(bignumstr, -skipdigits)) -- 5 length suffix
+	local msb = 0
+	for i= skipdigits + 1, string.len(bignumstr) do -- for each character of the big number string
+		local n = tonumber(string.sub(bignumstr,-i,-i)) -- get the current character
+		--print (i,string.sub(bignumstr,i,i),n)
+		for k = 1, n do  -- for each number value of current character
+			lsb = lsb + msblsb5[i - skipdigits][2] -- add the 16bit LSB of 10*i'th power
+			if lsb >= 65536 then -- if it overflows LSB, increment MSB
+				msb = msb + math.floor(lsb / 65536)
+				lsb = lsb % 65536
+			end
+			msb = msb + msblsb5[i - skipdigits][1] -- add the 16 bit MSB of 10*i'th power
+		end
+	end
+	--print (msb, lsb, lsb + msb *65536)
+	return lsb, msb
+end
 local function ParseBattleStatus(battleStatus)
-	battleStatus = tonumber(battleStatus)
+	local lsb, msb = split16fast(battleStatus)
+
+	--battleStatus = tonumber(battleStatus)
 	return {
-		isReady      = rshift(battleStatus, 1) % 2 == 1,
-		teamNumber   = rshift(battleStatus, 2) % 16,
-		allyNumber   = rshift(battleStatus, 6) % 16,
-		isSpectator  = rshift(battleStatus, 10) % 2 == 0,
-		handicap     = rshift(battleStatus, 11) % 128,
-		sync         = rshift(battleStatus, 22) % 4,
-		side         = rshift(battleStatus, 24) % 16,
+		isReady      = rshift(lsb, 1) % 2 == 1,
+		teamNumber   = rshift(lsb, 2) % 16,
+		allyNumber   = rshift(lsb, 6) % 16,
+		isSpectator  = rshift(lsb, 10) % 2 == 0,
+		handicap     = (lshift(msb, 5) + rshift(lsb, 11) ) % 128,
+		sync         = rshift(msb, 6) % 4,
+		side         = rshift(msb, 8) % 16,
 	}
 end
 

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -898,7 +898,8 @@ end
 -- Bots have isBot=true, AIs have aiLib~=nil and humans are the remaining
 -- Example: _OnUpdateUserStatus("gajop", {isAway=false, isInGame=true})
 function Lobby:_OnUpdateUserBattleStatus(userName, status)
-	if status.owner == nil and not self.users[userName] then
+	if status.owner == nil and not self.users[userName] or
+	   status.owner and not self.users[status.owner] then
 		Spring.Echo("[liblobby] Error OnUpdateUserBattleStatus: Tried to update non connected user in battle: ", userName)
 		return
 	end

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -894,13 +894,14 @@ function Lobby:_OnUpdateBattleInfo(battleID, battleInfo)
 end
 
 -- Updates the specified status keys
--- Status keys can be: isAway, isInGame, isModerator, rank, isBot, aiLib
--- Bots have isBot=true, AIs have aiLib~=nil and humans are the remaining
--- Example: _OnUpdateUserStatus("gajop", {isAway=false, isInGame=true})
+-- BattleStatus keys can be: isReady, teamNumber, allyNumber, isSpectator, handicap, sync, side
+-- chobby uses addiotional keys as status: teamColor
+-- Bots/AIs have additional keys inside chobby: owner~=nil, aiLib~=nil, aiOptions, aiVersion
+-- Example: _OnUpdateUserBattleStatus("gajop", {isReady=false, teamNumber=1})
 function Lobby:_OnUpdateUserBattleStatus(userName, status)
-	if status.owner == nil and not self.users[userName] or
-	   status.owner and not self.users[status.owner] then
-		Spring.Echo("[liblobby] Error OnUpdateUserBattleStatus: Tried to update non connected user in battle: ", userName)
+	if (status.owner == nil and not self.users[userName]) or
+	   (status.owner ~= nil and not self.users[status.owner]) then
+		Spring.Log(LOG_SECTION, LOG.ERROR, "Tried to update non connected user in battle: ", userName)
 		return
 	end
 	if not self.userBattleStatus[userName] then

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -898,6 +898,10 @@ end
 -- Bots have isBot=true, AIs have aiLib~=nil and humans are the remaining
 -- Example: _OnUpdateUserStatus("gajop", {isAway=false, isInGame=true})
 function Lobby:_OnUpdateUserBattleStatus(userName, status)
+	if status.owner == nil and not self.users[userName] then
+		Spring.Echo("[liblobby] Error OnUpdateUserBattleStatus: Tried to update non connected user in battle: ", userName)
+		return
+	end
 	if not self.userBattleStatus[userName] then
 		self.userBattleStatus[userName] = {}
 	end


### PR DESCRIPTION
Hi,
We faced a problem on bar infrastructure, where chobby shows players in battle, which were already removed from battle and are disconnected from server.
This is caused by receiving CLIENTBATTLESTATUS after LEFTBATTLE and REMOVEUSER was already sent. This leads to adding the user again to battle.

With this PR I added a check, if user is in list of connected users before adding him to the battle by CLIENTBATTLESTATUS.

Only testet in bar infrastructure. Can´t tell if it conflicts with other protocols and infrastructures.
Hope chances are good, that this has no negative effect in other environments.

best regards
Fireball

**Added: Don´t check user connected if updating status of a bot**
