### PR TITLE
Fix reference to undefined variable

### DIFF
--- a/libs/liblobby/lobby/interface_shared.lua
+++ b/libs/liblobby/lobby/interface_shared.lua
@@ -261,7 +261,7 @@ function Interface:_SocketUpdate()
 			-- nothing to do, return
 			return
 		end
-		Spring.Log(LOG_SECTION, LOG.ERROR, "Error in select: " .. error)
+		Spring.Log(LOG_SECTION, LOG.ERROR, "Error in select: " .. err)
 	end
 	for _, input in ipairs(readable) do
 		local s, status, commandsStr = input:receive('*a') --try to read all data


### PR DESCRIPTION
I don't know yet why the connection got the the state where `select` was returning error, but when it did, the logs were filled with:

```
[t=00:01:28.795429][f=-000001] [liblobby] Error: [string "libs/liblobby/lobby/interface_shared.lua"]:272: attempt to concatenate global 'error' (a function value)
[t=00:01:28.795529][f=-000001] [liblobby] Error: [string "libs/liblobby/lobby/interface_shared.lua"]:272: attempt to concatenate global 'error' (a function value)
stack traceback:
	[string "libs/liblobby/lobby/observable.lua"]:51: in function '_PrintError'
	[string "libs/liblobby/lobby/interface_shared.lua"]:313: in function <[string "libs/liblobby/lobby/interface_shared.lua"]:313>
	[string "libs/liblobby/lobby/interface_shared.lua"]:272: in function '_SocketUpdate'
	[string "libs/liblobby/lobby/interface_shared.lua"]:301: in function 'SafeUpdate'
	[string "libs/liblobby/lobby/interface_shared.lua"]:312: in function <[string "libs/liblobby/lobby/interface_shared.lua"]:312>
	[C]: in function 'xpcall'
	[string "libs/liblobby/lobby/interface_shared.lua"]:312: in function 'Update'
	[string "libs/liblobby/LuaMenu/widgets/api_lobby.lua"]:70: in function <[string "libs/liblobby/LuaMenu/widgets/api_lobby.lua"]:69>
	(tail call): ?
	[C]: in function 'pcall'
	[string "LuaHandler/Utilities/crashHandler.lua"]:50: in function 'f'
	[string "LuaHandler/Utilities/specialCallinHandlers.lua"]:80: in function <[string "LuaHandler/Utilities/specialCallinHandlers.lua"]:76>
```